### PR TITLE
Tea Limit validations

### DIFF
--- a/app/controllers/api/v1/customer_subscriptions_controller.rb
+++ b/app/controllers/api/v1/customer_subscriptions_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::CustomerSubscriptionsController < ApplicationController
 
   def create
     subscription = CustomerSubscription.new(subscription_params)
-    if subscription.save
+    if subscription.meets_limit(params[:tea]) && subscription.save
       subscription.add_teas(params[:tea])
       render json: CustomerSubscriptionSerializer.new_subscription(subscription), status: 201
     else

--- a/app/models/customer_subscription.rb
+++ b/app/models/customer_subscription.rb
@@ -7,6 +7,15 @@ class CustomerSubscription < ApplicationRecord
   validates_presence_of :frequency
   enum frequency: ["weekly", "monthly", "every 3 months", "yearly"]
 
+  def meets_limit(tea)
+    if tea.count > subscription.tea_limit
+      errors.add(:tea_limit, "This subscription has a limit of #{subscription.tea_limit} teas.")
+      return false
+    else
+      return true
+    end
+  end
+
   def add_teas(teas)
     teas.each do |tea|
       tea = Tea.find_by(name: tea)

--- a/app/models/customer_tea.rb
+++ b/app/models/customer_tea.rb
@@ -2,4 +2,13 @@ class CustomerTea < ApplicationRecord
   belongs_to :customer_subscription
   belongs_to :tea
   has_one :customer, through: :customer_subscription
+  has_one :subscription, through: :customer_subscription
+
+  # validate :tea_limit
+
+  # def tea_limit
+  #   if customer_subscription.teas.count == subscription.tea_limit
+  #     errors.add(:tea_limit, "Subscription has hit tea limit")
+  #   end
+  # end
 end

--- a/spec/requests/api/v1/subscriptions_requests_spec.rb
+++ b/spec/requests/api/v1/subscriptions_requests_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'subscriptions requests', type: :request do
       post "/api/v1/customers/#{customer_1.id}/subscriptions", headers: headers, params: JSON.generate(subscription_params)
 
       subscription_response = JSON.parse(response.body, symbolize_names: true)
+
       expect(response.status).to be(201)
       expect(subscription_response[:data]).to be_a Hash
       expect(subscription_response[:data]).to have_key(:name)
@@ -58,6 +59,23 @@ RSpec.describe 'subscriptions requests', type: :request do
       subscription_response = JSON.parse(response.body, symbolize_names: true)
       expect(response.status).to eq(400)
       expect(subscription_response[:errors]).to eq("Frequency can't be blank")
+    end
+
+    it 'can not add more teas to the customer subsciption than the subscription allows' do
+      tea = teas[0]
+      tea_2 = teas[4]
+      subscription_params = {
+        subscription_id: subscription_1.id,
+        frequency: "weekly",
+        tea: [tea.name, tea_2.name]
+      }
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v1/customers/#{customer_2.id}/subscriptions", headers: headers, params: JSON.generate(subscription_params)
+
+      subscription_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(subscription_response[:errors]).to eq("Tea limit This subscription has a limit of 1 teas.")
     end
   end
 


### PR DESCRIPTION
Add checks to ensure only a certain number of teas can be added to a subscription